### PR TITLE
Support Common Modules as locale files

### DIFF
--- a/bin/commands/sync.js
+++ b/bin/commands/sync.js
@@ -15,9 +15,7 @@ var _languages = require("../util/languages");
 
 var _source = require("../util/source");
 
-var _path = require("path");
-
-var _fs = require("fs");
+var _helpers = require("../util/helpers");
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
@@ -84,9 +82,7 @@ function _default(config) {
     sourceTranslations.forEach(function (segment) {
       updatedSourceTranslations[segment.key] = segment.target;
     });
-    (0, _fs.writeFileSync)((0, _path.join)(process.cwd(), config.translations_directory, "".concat(config.source_locale, ".json")), JSON.stringify(updatedSourceTranslations, null, 4), {
-      encoding: 'utf8'
-    });
+    (0, _helpers.writeLocaleFile)(config.source_locale, updatedSourceTranslations, config);
   }
 
   var api = new _Translation["default"](config);
@@ -114,9 +110,7 @@ function _default(config) {
       sourceTranslations.forEach(function (segment) {
         translations[segment.key] = segment.target;
       });
-      (0, _fs.writeFileSync)((0, _path.join)(process.cwd(), config.translations_directory, "".concat(config.source_locale, ".json")), JSON.stringify(translations, null, 4), {
-        encoding: 'utf8'
-      });
+      (0, _helpers.writeLocaleFile)(config.source_locale, translations, config);
     });
   }
 
@@ -133,9 +127,7 @@ function _default(config) {
           }
         }
       });
-      (0, _fs.writeFileSync)((0, _path.join)(process.cwd(), config.translations_directory, "".concat(locale, ".json")), JSON.stringify(translations, null, 4), {
-        encoding: 'utf8'
-      });
+      (0, _helpers.writeLocaleFile)(locale, translations, config);
     });
 
     if (config.purge) {

--- a/bin/util/helpers.js
+++ b/bin/util/helpers.js
@@ -1,0 +1,30 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.writeLocaleFile = void 0;
+
+var _fs = require("fs");
+
+var _util = require("util");
+
+var _path = require("path");
+
+var writeLocaleFile = function writeLocaleFile(locale, translations, config) {
+  var outputString,
+      fileExtension = 'json';
+
+  if (config.output === 'module') {
+    outputString = 'module.exports = ' + (0, _util.inspect)(translations, false, 2, false);
+    fileExtension = 'js';
+  } else {
+    outputString = JSON.stringify(translations, null, 4);
+  }
+
+  (0, _fs.writeFileSync)((0, _path.join)(process.cwd(), config.translations_directory, "".concat(locale, ".").concat(fileExtension)), outputString, {
+    encoding: 'utf8'
+  });
+};
+
+exports.writeLocaleFile = writeLocaleFile;

--- a/bin/util/languages.js
+++ b/bin/util/languages.js
@@ -29,11 +29,17 @@ var fetchSegmentsFromLanguageFiles = function fetchSegmentsFromLanguageFiles(con
   var languageFilesPath = (0, _path.resolve)(process.cwd(), config.translations_directory);
   var languageFiles = (0, _fs.readdirSync)(languageFilesPath).map(function (file) {
     var languagePath = (0, _path.resolve)(process.cwd(), config.translations_directory, file);
+    var languageObject;
 
-    var languageModule = require(languagePath);
+    if (config.output === 'module') {
+      languageObject = require(languagePath);
+    } else {
+      var languageModule = require(languagePath);
 
-    var defaultImport = languageModule["default"];
-    var languageObject = defaultImport ? defaultImport : languageModule;
+      var defaultImport = languageModule["default"];
+      languageObject = defaultImport ? defaultImport : languageModule;
+    }
+
     var fileName = file.replace(process.cwd(), '');
     return {
       fileName: fileName,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@translation/vue",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@translation/vue",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "MIT",
   "author": "Simon Depelchin",
   "publishConfig": {

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -2,8 +2,7 @@ import * as log from '../util/log'
 import Translation from '../Translation'
 import { fetchSegmentsFromLanguageFiles } from '../util/languages'
 import { fetchSegmentsFromVueFiles } from '../util/source'
-import { join } from 'path'
-import { writeFileSync } from 'fs'
+import { writeLocaleFile } from '../util/helpers'
 
 export default function(config) {
     log.info('Synchronizing project over Translation.io ...')
@@ -82,15 +81,7 @@ export default function(config) {
             updatedSourceTranslations[segment.key] = segment.target
         })
 
-        writeFileSync(
-            join(
-                process.cwd(),
-                config.translations_directory,
-                `${config.source_locale}.json`
-            ),
-            JSON.stringify(updatedSourceTranslations, null, 4),
-            { encoding: 'utf8' }
-        )
+        writeLocaleFile(config.source_locale, updatedSourceTranslations, config)
     }
 
     const api = new Translation(config)
@@ -128,15 +119,7 @@ export default function(config) {
                 translations[segment.key] = segment.target
             })
 
-            writeFileSync(
-                join(
-                    process.cwd(),
-                    config.translations_directory,
-                    `${config.source_locale}.json`
-                ),
-                JSON.stringify(translations, null, 4),
-                { encoding: 'utf8' }
-            )
+            writeLocaleFile(config.source_locale, translations, config)
         })
     }
 
@@ -156,15 +139,7 @@ export default function(config) {
                     }
                 })
 
-                writeFileSync(
-                    join(
-                        process.cwd(),
-                        config.translations_directory,
-                        `${locale}.json`
-                    ),
-                    JSON.stringify(translations, null, 4),
-                    { encoding: 'utf8' }
-                )
+                writeLocaleFile(locale, translations, config)
             })
 
             if (config.purge) {

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -1,0 +1,25 @@
+import { writeFileSync } from 'fs'
+import { inspect } from 'util'
+import { join } from 'path'
+
+const writeLocaleFile = (locale, translations, config) => {
+    let outputString, fileExtension = 'json'
+    if (config.output === 'module') {
+        outputString = 'module.exports = ' + inspect(translations, false, 2, false)
+        fileExtension = 'js'
+    } else {
+        outputString = JSON.stringify(translations, null, 4)
+    }
+
+    writeFileSync(
+        join(
+            process.cwd(),
+            config.translations_directory,
+            `${locale}.${fileExtension}`
+        ),
+        outputString,
+        { encoding: 'utf8' }
+    )
+}
+
+export { writeLocaleFile }

--- a/src/util/languages.js
+++ b/src/util/languages.js
@@ -22,10 +22,16 @@ export const fetchSegmentsFromLanguageFiles = config => {
             file
         )
 
-        const languageModule = require(languagePath)
-        const { default: defaultImport } = languageModule
+        let languageObject
 
-        const languageObject = defaultImport ? defaultImport : languageModule
+        if (config.output === 'module') {
+            languageObject = require(languagePath)
+        } else {
+            const languageModule = require(languagePath)
+            const { default: defaultImport } = languageModule
+
+            languageObject = defaultImport ? defaultImport : languageModule
+        }
 
         const fileName = file.replace(process.cwd(), '')
 

--- a/translation.json
+++ b/translation.json
@@ -1,5 +1,6 @@
 {
     "key": null,
+    "output": "json",
     "source_locale": "en",
     "target_locales": [],
     "source_path": "src/**/*.?(js|vue)",


### PR DESCRIPTION
This PR adds a `output` config option that can be `module` or `json`(default).

Based on this option, we will read and write the locale files accordingly.

This only supports Common Modules (`module.exports = {}`) at the moment.